### PR TITLE
Add gpio key event support for extension detection

### DIFF
--- a/recipes-kernel/linux/files/0021-gpio-keys-Add-keypad-slide-switch-event-support.patch
+++ b/recipes-kernel/linux/files/0021-gpio-keys-Add-keypad-slide-switch-event-support.patch
@@ -1,0 +1,34 @@
+From 9d1d02716aef83c20182ed066b082d1d2680b9d3 Mon Sep 17 00:00:00 2001
+From: Hiren Vadukul <hirenv@ext.mechasystems.com>
+Date: Thu, 11 Sep 2025 17:16:27 +0530
+Subject: [PATCH] gpio-keys: Add keypad slide switch event support
+
+Add keypad slide event to gpio-keys node for Comet Extension Keypad Slide
+
+Signed-off-by: Hiren Vadukul <hirenv@ext.mechasystems.com>
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-mecha-comet-m-gen6.dts b/arch/arm64/boot/dts/freescale/imx8mp-mecha-comet-m-gen6.dts
+index 7e3c0dfb8cca..f03108bfc801 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-mecha-comet-m-gen6.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-mecha-comet-m-gen6.dts
+@@ -142,6 +142,17 @@ usb3_data_ss: endpoint {
+ 			};
+ 		};
+ 	};
++
++	Comet-Extension {
++		compatible = "gpio-keys";
++
++		keypad-slide {
++			label = "Comet Extension Keypad Slide";
++			linux,input-type = <EV_SW>;
++			linux,code = <SW_KEYPAD_SLIDE>;
++			gpios = <&gpio4 23 GPIO_ACTIVE_HIGH>;
++		};
++	};
+ };
+ 
+ &usb3_0 {
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/recipes-kernel/linux/linux-imx_%.bbappend
@@ -22,6 +22,7 @@ SRC_URI:append = " file://0001-Added-ft3519-touchscreen-driver.patch \
 		   file://0018-usb-typec-Add-driver-for-TPS25751-PD-for-USB-1.patch \
 		   file://0019-usb-typec-Makefile-added-tps25751-driver.patch \
 		   file://0020-arm64-dts-added-support-for-USB-1-PD.patch \
+		   file://0021-gpio-keys-Add-keypad-slide-switch-event-support.patch \
 		   file://config.cfg \
 		   file://display-conf.cfg \
 		   file://nxp-imx95.cfg \


### PR DESCRIPTION
This patch adds support for gpio key event for
mecha comet extension device detection.